### PR TITLE
Include Magic Hash in base_url for resilience

### DIFF
--- a/app/scripts/html-tools.js
+++ b/app/scripts/html-tools.js
@@ -12,12 +12,16 @@ module.exports = {
   },
 
   generateFullHtmlFromFragment: function(fragment) {
+    var base_url = fragment.base_url.indexOf('#') > 0 ?
+                   fragment.base_url :
+                   fragment.base_url + '#';
+
     return "<!DOCTYPE html>" +
       "<html>" +
         "<head>" +
-          "<base href='" + fragment.base_url + "'>" +
+          "<base href='" + base_url + "'>" +
           "<meta content='text/html;charset=utf-8' http-equiv='Content-Type'>" +
-          "<title>content from " + fragment.base_url + "</title>" +
+          "<title>content from " + base_url + "</title>" +
           fragment.css +
         "</head>" +
         "<body>" +

--- a/dist/shutterbug.js
+++ b/dist/shutterbug.js
@@ -134,12 +134,16 @@ module.exports = {
   },
 
   generateFullHtmlFromFragment: function(fragment) {
+    var base_url = fragment.base_url.indexOf('#') > 0 ?
+                   fragment.base_url :
+                   fragment.base_url + '#';
+
     return "<!DOCTYPE html>" +
       "<html>" +
         "<head>" +
-          "<base href='" + fragment.base_url + "'>" +
+          "<base href='" + base_url + "'>" +
           "<meta content='text/html;charset=utf-8' http-equiv='Content-Type'>" +
-          "<title>content from " + fragment.base_url + "</title>" +
+          "<title>content from " + base_url + "</title>" +
           fragment.css +
         "</head>" +
         "<body>" +
@@ -618,4 +622,3 @@ module.exports = {
 // Do not force users to call require() manually, export Shutterbug constructor.
 // See: https://github.com/brunch/brunch/issues/712
 window.Shutterbug = require('scripts/shutterbug');
-


### PR DESCRIPTION
The server side shutterbug endpoint expects all iframes to have a "magic hash" in them, else it fails to decode them properly. Chrome's innerHTML encodes the payload using encodeURIComponent, but Firefox does not. Thus, Chrome's payload always works, but Firefox's only works when the URL includes a hash. Adding a hash to Chrome's URL does not affect its output.

By inspecting the URL to see if it already has a hash, and adding if it doesn't, we ensure that all sent URLs will be rendered properly.

See https://github.com/concord-consortium/shutterbug/commit/a203755475b32144b775d3de8d5306bc6a2bb9e1 for details.

Also see https://github.com/WikiWatershed/model-my-watershed/issues/1640 for motivation and discussion.