### PR TITLE
PhantomJS CSS transform fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .tmproj
 nbproject
 Thumbs.db
+.idea
 
 # NPM packages folder.
 node_modules/

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ After all elements are copied, emits a `shutterbug-asyouwere` event.
 
 ## Development
 
+Node.js v0.10 might be required. Please use NVM. In the future, build system should be switched to webpack. 
+
 This library is built with [Brunch](http://brunch.io).
 
 * Install (if you don't have them):
@@ -97,9 +99,9 @@ This library is built with [Brunch](http://brunch.io).
     * [Bower](http://bower.io): `npm install -g bower`
     * Brunch plugins and Bower dependencies: `npm install & bower install`.
 * Run:
-    * `brunch watch --server` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
+    * `npm run start` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
 * Build:
-    * `brunch build -e dist` — builds dist files
+    * `npm run build` — builds dist files
 * Learn:
     * `public/` dir is fully auto-generated and served by HTTP server.  Write your code in `app/` dir.
     * Place static files you want to be copied from `app/assets/` to `public/`.

--- a/app/scripts/shutterbug-worker.js
+++ b/app/scripts/shutterbug-worker.js
@@ -12,6 +12,44 @@ function getID() {
   return _id++;
 }
 
+// Replaces a few CSS rules that are not supported by PhantomJS.
+// cssText is assumed to be CSS content only, so it's safe to replace those words.
+// Even if they are in comments, it won't affect snapshot rendering.
+// Of course transformation from translate3d to 2d version won't work in all the cases. However, translate3d
+// won't work anyway, so it won't introduce any new bugs.
+function fixCSSTransformRules(cssText) {
+  if (window.__SHUTTERBUG_NO_3D_TRANSFORM_FIX__) {
+    // This preprocessing can be disabled using global __SHUTTERBUG_NO_3D_TRANSFORM_FIX__ flag.
+    // It might be set using browser console for debugging purposes.
+    return cssText
+  }
+  return cssText
+    .replace(/transform/g, '-webkit-transform') // affects both transform and transform-origin
+    .replace(/rotateZ/g, 'rotate')
+    .replace(/(translate3d)\((.+?),(.+?),(.+?)\)/g, function (match, translate3d, x, y, z) {
+      return 'translate(' + x + ',' + y + ')'
+    })
+}
+
+// Replaces a few CSS rules that are not supported by PhantomJS.
+// htmlText is a string with DOM markup. Function will only process inline styles or styles within <style> </style> tags.
+function fixHtmlInlineTransformRules(htmlText) {
+  if (window.__SHUTTERBUG_NO_3D_TRANSFORM_FIX__) {
+    // This preprocessing can be disabled using global __SHUTTERBUG_NO_3D_TRANSFORM_FIX__ flag.
+    // It might be set using browser console for debugging purposes.
+    return htmlText
+  }
+  return htmlText
+    .replace(/(<[\s\S]*?style=['"])([\s\S]*?)(['"][\s\S]*?[<\/|>])/g, function (match, prefix, styleContent, suffix) {
+      // Select inline styles and fix them.
+      return prefix + fixCSSTransformRules(styleContent) + suffix
+    })
+    .replace(/(<style[\s\S]*?)([\s\S]*?)(<\/style)/g, function (match, prefix, styleContent, suffix) {
+      // Select <style> </style> blocks and fix them.
+      return prefix + fixCSSTransformRules(styleContent) + suffix
+    })
+}
+
 function ShutterbugWorker(options) {
   var opt = options || {};
 
@@ -153,8 +191,8 @@ ShutterbugWorker.prototype.getHtmlFragment = function(callback) {
     }
 
     var html_content = {
-      content: $('<div>').append(element).html(),
-      css: css,
+      content: fixHtmlInlineTransformRules($('<div>').append(element).html()),
+      css: fixCSSTransformRules(css),
       width: width,
       height: height,
       base_url: window.location.href

--- a/app/scripts/shutterbug.js
+++ b/app/scripts/shutterbug.js
@@ -1,7 +1,7 @@
 var $ = typeof jQuery !== 'undefined' ? jQuery : require('jquery');
 var ShutterbugWorker = require('./shutterbug-worker');
 
-function parseSnapshotArguments(arguments) {
+function parseSnapshotArguments(args) {
   // Remember that selector is anything accepted by jQuery, it can be DOM element too.
   var selector;
   var doneCallback;
@@ -12,15 +12,15 @@ function parseSnapshotArguments(arguments) {
     else if (typeof arg === 'function') { doneCallback = arg; }
     else if (typeof arg === 'object')   { options      = arg; }
   }
-  if (arguments.length === 3) {
-    options = arguments[2];
-    assignSecondArgument(arguments[1]);
-    selector = arguments[0];
-  } else if (arguments.length === 2) {
-    assignSecondArgument(arguments[1]);
-    selector = arguments[0];
-  } else if (arguments.length === 1) {
-    options = arguments[0];
+  if (args.length === 3) {
+    options = args[2];
+    assignSecondArgument(args[1]);
+    selector = args[0];
+  } else if (args.length === 2) {
+    assignSecondArgument(args[1]);
+    selector = args[0];
+  } else if (args.length === 1) {
+    options = args[0];
   }
   if (selector)     { options.selector    = selector; }
   if (doneCallback) { options.done        = doneCallback; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,191 @@
+{
+  "name": "shutterbug",
+  "version": "0.6.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "after-brunch": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/after-brunch/-/after-brunch-0.0.5.tgz",
+      "integrity": "sha1-mMHBxGgM1w9eKfI5hFjuvWQKkf8=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
+    },
+    "auto-reload-brunch": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/auto-reload-brunch/-/auto-reload-brunch-1.7.8.tgz",
+      "integrity": "sha1-u+GTsmrYRlZpXMmpwLeyZVWZKx4=",
+      "dev": true,
+      "requires": {
+        "ws": "0.7.2"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
+    },
+    "clean-css": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+      "integrity": "sha1-29BaFIvklDuzfOBnnmdsvJ9YAmY=",
+      "dev": true,
+      "requires": {
+        "commander": "2.6.0",
+        "source-map": "0.1.43"
+      }
+    },
+    "clean-css-brunch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/clean-css-brunch/-/clean-css-brunch-1.7.2.tgz",
+      "integrity": "sha1-FOhan5VzjBXNhZ3JP5gqGZewIKo=",
+      "dev": true,
+      "requires": {
+        "clean-css": "3.1.9"
+      }
+    },
+    "commander": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+      "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+      "dev": true
+    },
+    "css-brunch": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/css-brunch/-/css-brunch-1.7.0.tgz",
+      "integrity": "sha1-JYwbA4qXCECvDGqOVYL2FAUClNo=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "javascript-brunch": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-brunch/-/javascript-brunch-1.7.1.tgz",
+      "integrity": "sha1-gIEMzYzloix1JaRsC7lLS7nYGF0=",
+      "dev": true,
+      "requires": {
+        "esprima": "1.0.4"
+      }
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.5.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "uglify-js-brunch": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/uglify-js-brunch/-/uglify-js-brunch-1.7.8.tgz",
+      "integrity": "sha1-s23/vNGc/qJySNNHl+/+8a6dOmI=",
+      "dev": true,
+      "requires": {
+        "uglify-js": "2.4.24"
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "ws": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
+      "integrity": "sha1-Q4xWC9+it9o91ba0btYTJcJGmdg=",
+      "dev": true,
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
+    },
+    "yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+      "dev": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "shutterbug",
   "description": "HTML Snapshot",
   "author": "Piotr Janik <janikpiotrek@gmail.com>",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "app/scripts/shutterbug.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/shutterbug.js"
   },
   "scripts": {
+    "build": "brunch build -e dist",
     "start": "brunch watch --server",
     "test": "brunch test"
   },
@@ -16,6 +17,7 @@
     "jquery": ">= 1.10.1"
   },
   "devDependencies": {
+    "brunch": "1.8.5",
     "javascript-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",
     "uglify-js-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
PhantomJS doesn't support `transform` rule, only `-webkit-transform` is supported. Also, 3D transformation is not supported. This PR tries to address those issues. It won't work in all the cases, as obviously it's impossible to change 3d transform to 2d. But since 3d transform is broken anyway, it won't hurt. It can help when websites use 3d transform due to performance reasons.

New code will try to parse and process:
- inline styles within HTML page
- styles within <style></style> tags
- external CSS  

Here's my regexp test case (terribly formated on purpose):
https://gist.github.com/pjanik/2fac8a41da87b4e67166d2a1bd49c471

I've tried to use this new version in Seismic Explorer and it works there.

<img width="663" alt="screen shot 2017-10-05 at 11 47 36" src="https://user-images.githubusercontent.com/767857/31216451-bcd25bea-a9c4-11e7-8804-22df69410a56.png">
Arrows are rotated correctly. Also, map tiles are possitioned in a right way without any pre-processing in the app (it was necessary before).