### PR TITLE
Support elements referencing Blob instances (e.g. CSS links or images)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ to the original code might be useful in the future.
 
 ## Changes ##
 
+* December 19, 2017 - v1.1.0
+    * Support HTML elements referencing Blob instances (e.g. CSS links or images using href/src="blob:http://example.com/abc-xyz-123")
+
 * October 14, 2017 - v1.0.1
     * `dist/shutterbug.js` is now transpiled to ES5 compatible code
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ to the original code might be useful in the future.
 
 * December 19, 2017 - v1.1.0
     * Support HTML elements referencing Blob instances (e.g. CSS links or images using href/src="blob:http://example.com/abc-xyz-123")
+    * Fix snapshot of Video elements
 
 * October 14, 2017 - v1.0.1
     * `dist/shutterbug.js` is now transpiled to ES5 compatible code

--- a/dist/demo/iframe.html
+++ b/dist/demo/iframe.html
@@ -14,10 +14,17 @@
   </head>
   <body>
     <div id="src">
-      (iframe)
+      (iframe with CSS link referencing Blob)
     </div>
   </body>
   <script type="text/javascript">
     Shutterbug.enable('#src');
+    // Generate CSS using Blob to test Blob replacement.
+    var blob = new Blob(['body { background: #93e07f; }'], {type: 'text/css'})
+    var link = document.createElement('link')
+    link.type = 'text/css'
+    link.rel = 'stylesheet'
+    link.href = URL.createObjectURL(blob)
+    document.head.appendChild(link)
   </script>
 </html>

--- a/dist/demo/iframe3.html
+++ b/dist/demo/iframe3.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <div id="src">
-      <p>(iframe that contains other iframes)</p>
+      <p>(iframe that contains other iframes and image with Blob source)</p>
       <iframe src="iframe.html" width="140" height="140"></iframe>
       <iframe src="iframe2.html" width="140" height="140"></iframe>
     </div>
@@ -22,5 +22,18 @@
   </body>
   <script type="text/javascript">
     Shutterbug.enable('#src');
+
+    // Add image using Blob to test Blob replacement.
+    var canvas = document.createElement('canvas');
+    canvas.width = 50;
+    canvas.height = 50;
+    var ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'red';
+    ctx.fillRect(0, 0, 50, 50)
+    canvas.toBlob(function (blob) {
+      var img = document.createElement('img');
+      img.src = URL.createObjectURL(blob)
+      document.getElementById('src').appendChild(img)
+    });
   </script>
 </html>

--- a/dist/shutterbug.js
+++ b/dist/shutterbug.js
@@ -560,9 +560,11 @@ function getDataURL(element) {
   var format = 'image/png';
   var realWidth = (0, _jquery2.default)(element).width();
   var realHeight = (0, _jquery2.default)(element).height();
+  // When element hasn't been added to DOM, realWidth and realHeight will be equal to 0.
+  var realDimensionsAvailable = realWidth > 0 && realHeight > 0;
   var widthAttr = Number((0, _jquery2.default)(element).attr('width')) || realWidth;
   var heightAttr = Number((0, _jquery2.default)(element).attr('height')) || realHeight;
-  if (realWidth === widthAttr && realHeight === heightAttr) {
+  if (!realDimensionsAvailable || realWidth === widthAttr && realHeight === heightAttr) {
     return element.toDataURL(format);
   }
   // Scale down image to its real size.

--- a/dist/shutterbug.js
+++ b/dist/shutterbug.js
@@ -195,7 +195,11 @@ var _jquery2 = _interopRequireDefault(_jquery);
 
 var _htmlTools = __webpack_require__(3);
 
-var _defaultServer = __webpack_require__(4);
+var _replaceBlobsWithDataUrls = __webpack_require__(4);
+
+var _replaceBlobsWithDataUrls2 = _interopRequireDefault(_replaceBlobsWithDataUrls);
+
+var _defaultServer = __webpack_require__(5);
 
 var _defaultServer2 = _interopRequireDefault(_defaultServer);
 
@@ -404,17 +408,25 @@ var ShutterbugWorker = function () {
           'height': $element.height()
         });
 
-        var htmlData = {
-          content: (0, _jquery2.default)('<div>').append(clonedElement).html(),
-          css: (0, _jquery2.default)('<div>').append((0, _jquery2.default)('link[rel="stylesheet"]').clone()).append((0, _jquery2.default)('style').clone()).html(),
-          width: $element.outerWidth(),
-          height: $element.outerHeight(),
-          base_url: window.location.href
-        };
+        var htmlString = (0, _jquery2.default)('<div>').append(clonedElement).html();
+        var cssString = (0, _jquery2.default)('<div>').append((0, _jquery2.default)('link[rel="stylesheet"]').clone()).append((0, _jquery2.default)('style').clone()).html();
+        // Process HTML and CSS content when it's a string. Some operations are easier when we can use regular expressions
+        // instead of traversing the DOM using jQuery.
+        var htmlDeferred = (0, _replaceBlobsWithDataUrls2.default)(htmlString);
+        var cssDeferred = (0, _replaceBlobsWithDataUrls2.default)(cssString);
+        _jquery2.default.when(htmlDeferred, cssDeferred).done(function (processedHTMLString, processedCssString) {
+          var htmlData = {
+            content: processedHTMLString,
+            css: processedCssString,
+            width: $element.outerWidth(),
+            height: $element.outerHeight(),
+            base_url: window.location.href
+          };
 
-        $element.trigger('shutterbug-asyouwere');
+          $element.trigger('shutterbug-asyouwere');
 
-        callback(htmlData);
+          callback(htmlData);
+        });
       });
     }
 
@@ -569,6 +581,77 @@ function generateFullHtmlFromFragment(fragment) {
 
 /***/ }),
 /* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = replaceBlobsWithDataURLs;
+
+var _jquery = __webpack_require__(0);
+
+var _jquery2 = _interopRequireDefault(_jquery);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Downloads `blobURL` and provides object with mapping to dataURL format.
+// Async function, returns $.Deferred instance that will be resolved with the mapping.
+function convertBlobToDataURL(blobURL) {
+  var requestDeferred = new _jquery2.default.Deferred();
+  var xhr = new XMLHttpRequest();
+  xhr.onreadystatechange = function () {
+    if (this.readyState === 4 && this.status === 200) {
+      var reader = new FileReader();
+      reader.addEventListener('loadend', function () {
+        requestDeferred.resolve({ blobURL: blobURL, dataURL: reader.result });
+      });
+      reader.readAsDataURL(this.response);
+    }
+  };
+  xhr.open('GET', blobURL);
+  xhr.responseType = 'blob';
+  xhr.send();
+  return requestDeferred;
+}
+
+// Converts all the blob URLs (e.g. "blob:http://examples.com/abc-def-ghi") in `htmlString` to data URLs.
+// Async function, returns $.Deferred instance that will be resolved with the final HTML.
+/* eslint-env browser */
+function replaceBlobsWithDataURLs(htmlString) {
+  var deferred = new _jquery2.default.Deferred();
+  var blobURLs = htmlString.match(/["']blob:.*?["']/gi);
+  if (blobURLs === null) {
+    // Nothing to do.
+    deferred.resolve(htmlString);
+    return deferred;
+  }
+
+  var blobRequests = blobURLs
+  // .slice(1, -1) removes " or ' from the URI.
+  .map(function (blobURLWithQuotes) {
+    return blobURLWithQuotes.slice(1, -1);
+  }).map(function (blobURL) {
+    return convertBlobToDataURL(blobURL);
+  });
+
+  _jquery2.default.when.apply(_jquery2.default, blobRequests).done(function () {
+    // Convert arguments to real Array instance.
+    var mappings = Array.prototype.slice.call(arguments);
+    var newHtmlString = htmlString;
+    mappings.forEach(function (mapping) {
+      newHtmlString = newHtmlString.replace(mapping.blobURL, mapping.dataURL);
+    });
+    deferred.resolve(newHtmlString);
+  });
+
+  return deferred;
+}
+
+/***/ }),
+/* 5 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";

--- a/js/html-tools.js
+++ b/js/html-tools.js
@@ -20,9 +20,11 @@ export function getDataURL (element) {
   const format = 'image/png'
   const realWidth = $(element).width()
   const realHeight = $(element).height()
+  // When element hasn't been added to DOM, realWidth and realHeight will be equal to 0.
+  const realDimensionsAvailable = realWidth > 0 && realHeight > 0
   const widthAttr = Number($(element).attr('width')) || realWidth
   const heightAttr = Number($(element).attr('height')) || realHeight
-  if (realWidth === widthAttr && realHeight === heightAttr) {
+  if (!realDimensionsAvailable || realWidth === widthAttr && realHeight === heightAttr) {
     return element.toDataURL(format)
   }
   // Scale down image to its real size.

--- a/js/replace-blobs-with-data-urls.js
+++ b/js/replace-blobs-with-data-urls.js
@@ -1,0 +1,51 @@
+/* eslint-env browser */
+import $ from 'jquery'
+
+// Downloads `blobURL` and provides object with mapping to dataURL format.
+// Async function, returns $.Deferred instance that will be resolved with the mapping.
+function convertBlobToDataURL (blobURL) {
+  const requestDeferred = new $.Deferred()
+  const xhr = new XMLHttpRequest()
+  xhr.onreadystatechange = function () {
+    if (this.readyState === 4 && this.status === 200) {
+      const reader = new FileReader()
+      reader.addEventListener('loadend', function () {
+        requestDeferred.resolve({blobURL, dataURL: reader.result})
+      })
+      reader.readAsDataURL(this.response)
+    }
+  }
+  xhr.open('GET', blobURL)
+  xhr.responseType = 'blob'
+  xhr.send()
+  return requestDeferred
+}
+
+// Converts all the blob URLs (e.g. "blob:http://examples.com/abc-def-ghi") in `htmlString` to data URLs.
+// Async function, returns $.Deferred instance that will be resolved with the final HTML.
+export default function replaceBlobsWithDataURLs (htmlString) {
+  const deferred = new $.Deferred()
+  const blobURLs = htmlString.match(/["']blob:.*?["']/gi)
+  if (blobURLs === null) {
+    // Nothing to do.
+    deferred.resolve(htmlString)
+    return deferred
+  }
+
+  const blobRequests = blobURLs
+    // .slice(1, -1) removes " or ' from the URI.
+    .map(blobURLWithQuotes => blobURLWithQuotes.slice(1, -1))
+    .map(blobURL => convertBlobToDataURL(blobURL))
+
+  $.when.apply($, blobRequests).done(function () {
+    // Convert arguments to real Array instance.
+    const mappings = Array.prototype.slice.call(arguments)
+    let newHtmlString = htmlString
+    mappings.forEach(mapping => {
+      newHtmlString = newHtmlString.replace(mapping.blobURL, mapping.dataURL)
+    })
+    deferred.resolve(newHtmlString)
+  })
+
+  return deferred
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shutterbug",
   "description": "HTML Snapshot",
   "author": "Piotr Janik <janikpiotrek@gmail.com>",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/shutterbug.js",
   "repository": {
     "type": "git",

--- a/public/demo/iframe.html
+++ b/public/demo/iframe.html
@@ -14,10 +14,17 @@
   </head>
   <body>
     <div id="src">
-      (iframe)
+      (iframe with CSS link referencing Blob)
     </div>
   </body>
   <script type="text/javascript">
     Shutterbug.enable('#src');
+    // Generate CSS using Blob to test Blob replacement.
+    var blob = new Blob(['body { background: #93e07f; }'], {type: 'text/css'})
+    var link = document.createElement('link')
+    link.type = 'text/css'
+    link.rel = 'stylesheet'
+    link.href = URL.createObjectURL(blob)
+    document.head.appendChild(link)
   </script>
 </html>

--- a/public/demo/iframe3.html
+++ b/public/demo/iframe3.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <div id="src">
-      <p>(iframe that contains other iframes)</p>
+      <p>(iframe that contains other iframes and image with Blob source)</p>
       <iframe src="iframe.html" width="140" height="140"></iframe>
       <iframe src="iframe2.html" width="140" height="140"></iframe>
     </div>
@@ -22,5 +22,18 @@
   </body>
   <script type="text/javascript">
     Shutterbug.enable('#src');
+
+    // Add image using Blob to test Blob replacement.
+    var canvas = document.createElement('canvas');
+    canvas.width = 50;
+    canvas.height = 50;
+    var ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'red';
+    ctx.fillRect(0, 0, 50, 50)
+    canvas.toBlob(function (blob) {
+      var img = document.createElement('img');
+      img.src = URL.createObjectURL(blob)
+      document.getElementById('src').appendChild(img)
+    });
   </script>
 </html>


### PR DESCRIPTION
While working on Plate Tectonics 3D, I've noticed that Shutterbug completely ignores most of the CSS rules. It turns out that webpack / css-loader generates lots of CSS links referencing local Blob instances, e.g.:
`<link rel="stylesheet" href="blob:http://models-resources.concord.org/6d1f204e-5d59-47dc-bf18-4d2ca55c10ee">`
Since we have many projects using webpack and this problem can happen more often in the future, I've tried to add support of Blobs to Shutterbug.js.

I've already updated demo, so you can test that in practive:
http://concord-consortium.github.io/shutterbug.js/demo/nested-iframe-example.html
A small, red square and green background of the iframe are defined using Blobs.

