### PR TITLE
Set source of iframe using `srcdoc` instead of `src=data:text/html,`

### DIFF
--- a/dist/demo/hurricane-example.html
+++ b/dist/demo/hurricane-example.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+      <title>demo</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../shutterbug.js"></script>
+    <style type="text/css">
+      body {
+        font-family: Verdana, Arial, sans-serif;
+        padding: 0 10px;
+      }
+      div, iframe, button {
+        margin-bottom: 10px;
+      }
+      button {
+        display: block;
+        font-size: 20px;
+      }
+      #src1, #src2 {
+        border: 2px solid #b4130c;
+      }
+      #dst1, #dst2 {
+        display: inline-block;
+        border: 2px solid #3f16b4;
+        padding: 3px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h3>Hurricane model </h3>
+    <iframe id="src2" src="https://hurricane.concord.org/branch/master/index.html?overlay=stormSurge" width="1000" height="800"></iframe>
+    <button id="shutterbug1">Snapshot</button>
+    <div><div id="dst1">Destination container</div></div>
+    <h3>Hurricane model (long URL)</h3>
+    <iframe id="src1" src="https://hurricane.concord.org/branch/master/index.html?overlay=stormSurge&pressureSystems=%5B%7B%22type%22%3A%22high%22%2C%22center%22%3A%7B%22lat%22%3A26.705439761115944%2C%22lng%22%3A-32.88242340087891%7D%2C%22strength%22%3A20%7D%2C%7B%22type%22%3A%22high%22%2C%22center%22%3A%7B%22lat%22%3A25.310511227182708%2C%22lng%22%3A-57.794609069824226%7D%2C%22strength%22%3A13%7D%2C%7B%22type%22%3A%22low%22%2C%22center%22%3A%7B%22lat%22%3A47.2480086373258%2C%22lng%22%3A-65.4943084716797%7D%2C%22strength%22%3A7%7D%2C%7B%22type%22%3A%22low%22%2C%22center%22%3A%7B%22lat%22%3A44.762824214255026%2C%22lng%22%3A-86.83593750000001%7D%2C%22strength%22%3A6%7D%5D" width="1000" height="800"></iframe>
+    <button id="shutterbug2">Snapshot</button>
+    <div><div id="dst2">Destination container</div></div>
+
+  </body>
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $("#shutterbug1").click(function() {
+        Shutterbug.snapshot("#src1", "#dst1");
+      });
+      $("#shutterbug2").click(function() {
+        Shutterbug.snapshot("#src2", "#dst2");
+      });
+    });
+  </script>
+</html>

--- a/dist/demo/index.html
+++ b/dist/demo/index.html
@@ -24,6 +24,7 @@
       <li><a href="video-iframe-example.html">Video instide an iframe</a></li>
       <li><a href="lab-example.html">Lab interactives</a></li>
       <li><a href="seismic-explorer-example.html">Seismic Explorer interactive</a></li>
+      <li><a href="hurricane-example.html">Hurricane Explorer interactive</a></li>
     </ul>
   </body>
 </html>

--- a/dist/shutterbug.js
+++ b/dist/shutterbug.js
@@ -344,7 +344,7 @@ var ShutterbugWorker = function () {
             // When iframe doesn't support Shutterbug, request will timeout and null will be received.
             // In such case just ignore this iframe, we won't be able to render it.
             if (nestedIFrames[i] == null) return;
-            (0, _jquery2.default)(iframeElem).attr('src', 'data:text/html,' + (0, _htmlTools.generateFullHtmlFromFragment)(nestedIFrames[i]));
+            (0, _jquery2.default)(iframeElem).attr('srcdoc', (0, _htmlTools.generateFullHtmlFromFragment)(nestedIFrames[i]));
           });
         }
 
@@ -662,9 +662,13 @@ function replaceBlobsWithDataURLs(htmlString) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+// Production:
 var DEFAULT_SERVER = 'https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production';
-// To work with local Shutterbug server use:
-// const DEFAULT_SERVER = 'http://localhost:3000'
+// Staging:
+// const DEFAULT_SERVER = 'https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging'
+// Local:
+// const DEFAULT_SERVER = 'http://localhost:4000'
+
 exports.default = DEFAULT_SERVER;
 
 /***/ })

--- a/js/default-server.js
+++ b/js/default-server.js
@@ -1,4 +1,8 @@
+// Production:
 const DEFAULT_SERVER = 'https://fh1fzvhx93.execute-api.us-east-1.amazonaws.com/production'
-// To work with local Shutterbug server use:
-// const DEFAULT_SERVER = 'http://localhost:3000'
+// Staging:
+// const DEFAULT_SERVER = 'https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging'
+// Local:
+// const DEFAULT_SERVER = 'http://localhost:4000'
+
 export default DEFAULT_SERVER

--- a/js/html-tools.js
+++ b/js/html-tools.js
@@ -24,7 +24,7 @@ export function getDataURL (element) {
   const realDimensionsAvailable = realWidth > 0 && realHeight > 0
   const widthAttr = Number($(element).attr('width')) || realWidth
   const heightAttr = Number($(element).attr('height')) || realHeight
-  if (!realDimensionsAvailable || realWidth === widthAttr && realHeight === heightAttr) {
+  if (!realDimensionsAvailable || (realWidth === widthAttr && realHeight === heightAttr)) {
     return element.toDataURL(format)
   }
   // Scale down image to its real size.

--- a/js/shutterbug-worker.js
+++ b/js/shutterbug-worker.js
@@ -125,7 +125,7 @@ export default class ShutterbugWorker {
           // When iframe doesn't support Shutterbug, request will timeout and null will be received.
           // In such case just ignore this iframe, we won't be able to render it.
           if (nestedIFrames[i] == null) return
-          $(iframeElem).attr('src', 'data:text/html,' + generateFullHtmlFromFragment(nestedIFrames[i]))
+          $(iframeElem).attr('srcdoc', generateFullHtmlFromFragment(nestedIFrames[i]))
         })
       }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shutterbug",
   "description": "HTML Snapshot",
   "author": "Piotr Janik <janikpiotrek@gmail.com>",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/shutterbug.js",
   "repository": {
     "type": "git",

--- a/public/demo/hurricane-example.html
+++ b/public/demo/hurricane-example.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+      <title>demo</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../shutterbug.js"></script>
+    <style type="text/css">
+      body {
+        font-family: Verdana, Arial, sans-serif;
+        padding: 0 10px;
+      }
+      div, iframe, button {
+        margin-bottom: 10px;
+      }
+      button {
+        display: block;
+        font-size: 20px;
+      }
+      #src1, #src2 {
+        border: 2px solid #b4130c;
+      }
+      #dst1, #dst2 {
+        display: inline-block;
+        border: 2px solid #3f16b4;
+        padding: 3px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h3>Hurricane model </h3>
+    <iframe id="src2" src="https://hurricane.concord.org/branch/master/index.html?overlay=stormSurge" width="1000" height="800"></iframe>
+    <button id="shutterbug1">Snapshot</button>
+    <div><div id="dst1">Destination container</div></div>
+    <h3>Hurricane model (long URL)</h3>
+    <iframe id="src1" src="https://hurricane.concord.org/branch/master/index.html?overlay=stormSurge&pressureSystems=%5B%7B%22type%22%3A%22high%22%2C%22center%22%3A%7B%22lat%22%3A26.705439761115944%2C%22lng%22%3A-32.88242340087891%7D%2C%22strength%22%3A20%7D%2C%7B%22type%22%3A%22high%22%2C%22center%22%3A%7B%22lat%22%3A25.310511227182708%2C%22lng%22%3A-57.794609069824226%7D%2C%22strength%22%3A13%7D%2C%7B%22type%22%3A%22low%22%2C%22center%22%3A%7B%22lat%22%3A47.2480086373258%2C%22lng%22%3A-65.4943084716797%7D%2C%22strength%22%3A7%7D%2C%7B%22type%22%3A%22low%22%2C%22center%22%3A%7B%22lat%22%3A44.762824214255026%2C%22lng%22%3A-86.83593750000001%7D%2C%22strength%22%3A6%7D%5D" width="1000" height="800"></iframe>
+    <button id="shutterbug2">Snapshot</button>
+    <div><div id="dst2">Destination container</div></div>
+
+  </body>
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $("#shutterbug1").click(function() {
+        Shutterbug.snapshot("#src1", "#dst1");
+      });
+      $("#shutterbug2").click(function() {
+        Shutterbug.snapshot("#src2", "#dst2");
+      });
+    });
+  </script>
+</html>

--- a/public/demo/index.html
+++ b/public/demo/index.html
@@ -24,6 +24,7 @@
       <li><a href="video-iframe-example.html">Video instide an iframe</a></li>
       <li><a href="lab-example.html">Lab interactives</a></li>
       <li><a href="seismic-explorer-example.html">Seismic Explorer interactive</a></li>
+      <li><a href="hurricane-example.html">Hurricane Explorer interactive</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
[#169504366]
https://www.pivotaltracker.com/story/show/169504366

It seems to be necessary to work with the new Shutterbug server / Chrome version and fixes some issues.

I've tested a bunch of examples using our demo pages here and actually this change works fine with the old server. Previously I thought it doesn't, as I was testing a specific model that simply doesn't work with the old server. So, I think we should update apps (interactives) before we update the server / Lambda.