### PR TITLE
add a generic iframe test page

### DIFF
--- a/dist/demo/iframe-test.html
+++ b/dist/demo/iframe-test.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+  <head>
+      <title>demo</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../shutterbug.js"></script>
+    <style type="text/css">
+      body {
+        font-family: Verdana, Arial, sans-serif;
+        padding: 0 10px;
+      }
+      div, iframe, button {
+        margin-bottom: 10px;
+      }
+      button.snapshot {
+        display: block;
+        font-size: 20px;
+      }
+      #src1 {
+        border: 2px solid #b4130c;
+      }
+      #dst1 {
+        display: inline-block;
+        border: 2px solid #3f16b4;
+        padding: 3px;
+      }
+      .url-field {
+        width: 600px;
+      }
+      .dimension-field {
+        width: 50px;
+      }
+      label {
+        padding-right: 6px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <label>URL</label>
+      <input id="url-field" class="url-field" type="text"></input>
+      <br>
+      <label>Width</label><input id="width" class="dimensiont-field" type="text"></input>
+      <label>Height</label><input id="height" class="dimensiont-field" type="text"></input>
+      <button id="update">Update iframe</button>
+    </div>
+    <iframe id="src1"></iframe>
+    <button class="snapshot" id="shutterbug1">Snapshot</button>
+    <div><div id="dst1">Destination container</div></div>
+  </body>
+  <script type="text/javascript">
+    function update() {
+      const url = $("#url-field").val(),
+        width = $("#width").val(),
+        height = $("#height").val();
+
+      $("#src1")
+        .attr('width', width)
+        .attr('height', height)
+        .attr('src', url);
+
+      let params = new URLSearchParams()
+      params.set("url", url);
+      params.set("width", width);
+      params.set("height", height);
+      history.pushState({}, "", "?" + params.toString());
+    }
+
+    $(document).ready(function() {
+      // read the URL parameter for url, width, and height
+      // construct the iframe element based on these
+      let params = (new URL(document.location)).searchParams;
+
+      $("#url-field").val(params.get('url'));
+      $("#width").val(params.get('width') || '800');
+      $("#height").val(params.get('height') || '600');
+
+      update();
+
+      $("#update").click(function () {
+        update();
+      })
+
+      $("#shutterbug1").click(function() {
+        Shutterbug.snapshot("#src1", "#dst1");
+      });
+    });
+  </script>
+</html>

--- a/dist/demo/index.html
+++ b/dist/demo/index.html
@@ -11,6 +11,10 @@
     </style>
   </head>
   <body>
+    <p>
+      <a href="iframe-test.html">Iframe Test Page</a>
+    </p>
+
     Examples:
     <ul>
       <li><a href="simple-example.html">Basic</a></li>

--- a/public/demo/iframe-test.html
+++ b/public/demo/iframe-test.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+  <head>
+      <title>demo</title>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../shutterbug.js"></script>
+    <style type="text/css">
+      body {
+        font-family: Verdana, Arial, sans-serif;
+        padding: 0 10px;
+      }
+      div, iframe, button {
+        margin-bottom: 10px;
+      }
+      button.snapshot {
+        display: block;
+        font-size: 20px;
+      }
+      #src1 {
+        border: 2px solid #b4130c;
+      }
+      #dst1 {
+        display: inline-block;
+        border: 2px solid #3f16b4;
+        padding: 3px;
+      }
+      .url-field {
+        width: 600px;
+      }
+      .dimension-field {
+        width: 50px;
+      }
+      label {
+        padding-right: 6px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <label>URL</label>
+      <input id="url-field" class="url-field" type="text"></input>
+      <br>
+      <label>Width</label><input id="width" class="dimensiont-field" type="text"></input>
+      <label>Height</label><input id="height" class="dimensiont-field" type="text"></input>
+      <button id="update">Update iframe</button>
+    </div>
+    <iframe id="src1"></iframe>
+    <button class="snapshot" id="shutterbug1">Snapshot</button>
+    <div><div id="dst1">Destination container</div></div>
+  </body>
+  <script type="text/javascript">
+    function update() {
+      const url = $("#url-field").val(),
+        width = $("#width").val(),
+        height = $("#height").val();
+
+      $("#src1")
+        .attr('width', width)
+        .attr('height', height)
+        .attr('src', url);
+
+      let params = new URLSearchParams()
+      params.set("url", url);
+      params.set("width", width);
+      params.set("height", height);
+      history.pushState({}, "", "?" + params.toString());
+    }
+
+    $(document).ready(function() {
+      // read the URL parameter for url, width, and height
+      // construct the iframe element based on these
+      let params = (new URL(document.location)).searchParams;
+
+      $("#url-field").val(params.get('url'));
+      $("#width").val(params.get('width') || '800');
+      $("#height").val(params.get('height') || '600');
+
+      update();
+
+      $("#update").click(function () {
+        update();
+      })
+
+      $("#shutterbug1").click(function() {
+        Shutterbug.snapshot("#src1", "#dst1");
+      });
+    });
+  </script>
+</html>

--- a/public/demo/index.html
+++ b/public/demo/index.html
@@ -11,6 +11,10 @@
     </style>
   </head>
   <body>
+    <p>
+      <a href="iframe-test.html">Iframe Test Page</a>
+    </p>
+
     Examples:
     <ul>
       <li><a href="simple-example.html">Basic</a></li>


### PR DESCRIPTION
This adds a generic test page where the user can enter in an iframe url, width and height.
These values can also be loaded using URL parameters. 
The URL parameters are also updated if the form field changes.

This should be make it easier to add links to demo snapshots of interactives.
We can also put this on github pages before the 1.3.0 release, to help testing out that new release.